### PR TITLE
Allow negative user ids

### DIFF
--- a/debug_toolbar_user_panel/urls.py
+++ b/debug_toolbar_user_panel/urls.py
@@ -7,6 +7,6 @@ urlpatterns = patterns('debug_toolbar_user_panel.views',
         name='debug-userpanel'),
     url(r'^%s/users/login/$' % _PREFIX, 'login_form',
         name='debug-userpanel-login-form'),
-    url(r'^%s/users/login/(?P<pk>\d+)$' % _PREFIX, 'login',
+    url(r'^%s/users/login/(?P<pk>-?\d+)$' % _PREFIX, 'login',
         name='debug-userpanel-login'),
 )


### PR DESCRIPTION
django guardian requires an 'anoymous user id' setting.
In projects using guardian, this is often configured to be '-1'

The loop in the template for the user list throws an Exception because it can't find a matching reverse url for an id = -1
