### PR TITLE
New Feature: Force initial login as superuser (resubmission)

### DIFF
--- a/debug_toolbar_user_panel/panels.py
+++ b/debug_toolbar_user_panel/panels.py
@@ -61,6 +61,7 @@ File a bug
 
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from debug_toolbar.panels import DebugPanel
 
@@ -91,6 +92,12 @@ class UserPanel(DebugPanel):
         })
 
         return render_to_string('debug_toolbar_user_panel/panel.html', context)
+
+    def process_request(self, request):
+        force_secure = not getattr(settings, 'DEBUG_TOOLBAR_USER_PANEL_SECURE', False)
+        enabled = request.user.is_superuser or force_secure
+        if not 'debug_toolbar_user_panel_enabled' in request.session and enabled:
+            request.session['debug_toolbar_user_panel_enabled'] = True
 
     def process_response(self, request, response):
         self.request = request

--- a/debug_toolbar_user_panel/templates/debug_toolbar_user_panel/content.html
+++ b/debug_toolbar_user_panel/templates/debug_toolbar_user_panel/content.html
@@ -1,33 +1,37 @@
-<h4>Current user</h4>
+{% if enabled %}
+  <h4>Current user</h4>
 
-{% if request.user.is_authenticated %}
-  <table>
-    <tr>{% for x,y in current %}<th>{{ x }}</th>{% endfor %}</tr>
-    <tr>{% for x,y in current %}<td>{{ y }}</td>{% endfor %}</tr>
-  </table>
+  {% if request.user.is_authenticated %}
+    <table>
+      <tr>{% for x,y in current %}<th>{{ x }}</th>{% endfor %}</tr>
+      <tr>{% for x,y in current %}<td>{{ y }}</td>{% endfor %}</tr>
+    </table>
+  {% else %}
+    <p>Not logged in.</p>
+  {% endif %}
+
+  <h4>Recent users</h4>
+
+  <ul>
+    {% for user in users %}
+    <li>
+      <form method="POST" action="{% url debug-userpanel-login user.pk %}">
+        {% csrf_token %}
+        {% if next %}
+        <input type="hidden" name="next" value="{{ next }}">
+        {% endif %}
+        <button class="login" type="submit">{{ user }}</button>
+      </form>
+    </li>
+    {% endfor %}
+  </ul>
+
+  <h4>Login as any user</h4>
+
+  <form method="POST" action="{% url debug-userpanel-login-form %}">
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+  </form>
 {% else %}
-  <p>Not logged in.</p>
+  <h4>You must start logged in with a super user to use this feature</h4>
 {% endif %}
-
-<h4>Recent users</h4>
-
-<ul>
-  {% for user in users %}
-  <li>
-    <form method="POST" action="{% url debug-userpanel-login user.pk %}">
-      {% csrf_token %}
-      {% if next %}
-      <input type="hidden" name="next" value="{{ next }}">
-      {% endif %}
-      <button class="login" type="submit">{{ user }}</button>
-    </form>
-  </li>
-  {% endfor %}
-</ul>
-
-<h4>Login as any user</h4>
-
-<form method="POST" action="{% url debug-userpanel-login-form %}">
-  {{ form.as_p }}
-  <button type="submit">Login</button>
-</form>

--- a/debug_toolbar_user_panel/views.py
+++ b/debug_toolbar_user_panel/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import render_to_response, get_object_or_404
 from django.contrib.auth.models import User
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.core.exceptions import PermissionDenied
 
 from .forms import UserForm
 
@@ -25,11 +26,14 @@ def content(request):
         'next': request.GET.get('next'),
         'users': User.objects.order_by('-last_login')[:10],
         'current': current,
+        'enabled': request.session.get('debug_toolbar_user_panel_enabled', False),
     }, context_instance=RequestContext(request))
 
 @csrf_exempt
 @require_POST
 def login_form(request):
+    if not request.session.get('debug_toolbar_user_panel_enabled', False):
+        raise PermissionDenied
     form = UserForm(request.POST)
 
     if not form.is_valid():
@@ -40,6 +44,8 @@ def login_form(request):
 @csrf_exempt
 @require_POST
 def login(request, **kwargs):
+    if not request.session.get('debug_toolbar_user_panel_enabled', False):
+        raise PermissionDenied
     user = get_object_or_404(User, **kwargs)
 
     user.backend = settings.AUTHENTICATION_BACKENDS[0]


### PR DESCRIPTION
The user panel now looks for `DEBUG_TOOLBAR_USER_PANEL_SECURE` in the
settings module.  If set to `True`, the user panel will only function if
logged in initially as a superuser.  If the setting is not present, the
toolbar defaults to being enabled.

Added `process_request` method to panel which sets an 'enabled' flag on the session based
on whether the toolbar should be enabled or not.

Added conditional to content template to hide all forms and show a help
message if the panel is disabled.

Added logic to views to check if the toolbar should be disabled.  In
primary view, an enabled flag has been added to the template context.
In the `login` and `login_form` views, the django `PermissionDenied`
exception is raised.
