### PR TITLE
Adding new debug setting to allow the use of the user panel when DEBUG is False

### DIFF
--- a/debug_toolbar_user_panel/decorators.py
+++ b/debug_toolbar_user_panel/decorators.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseForbidden
 def debug_required(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        if not settings.DEBUG:
+        if not getattr(settings, 'DEBUG_TOOLBAR_USER_DEBUG', settings.DEBUG):
             return HttpResponseForbidden()
         return fn(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
Adding this new setting allows for users to set their own preference for using the toolbar when DEBUG = False without having to set DEBUG to True.
