### PR TITLE
Current User shows "Not logged in" all the time

### DIFF
--- a/debug_toolbar_user_panel/templates/debug_toolbar_user_panel/content.html
+++ b/debug_toolbar_user_panel/templates/debug_toolbar_user_panel/content.html
@@ -2,7 +2,7 @@
 
 <h4>Current user</h4>
 
-{% if request.user.is_authenticated %}
+{% if user.is_authenticated %}
   <table>
     <tr>{% for x,y in current %}<th>{{ x }}</th>{% endfor %}</tr>
     <tr>{% for x,y in current %}<td>{{ y }}</td>{% endfor %}</tr>


### PR DESCRIPTION
`request.user` can be accessed from views not from templates (according to the documentation).

https://docs.djangoproject.com/en/1.4/topics/auth/#authentication-in-web-requests

From templates it's the context variable user, from:
https://docs.djangoproject.com/en/1.4/topics/auth/#id8

At least since 1.0 (in the docs) can be accessed this way.

This, according to the docs, may stay the same in 1.5 but, on the view layer may need to change a little.
